### PR TITLE
去掉上下文的判断

### DIFF
--- a/src/AbstractPool.php
+++ b/src/AbstractPool.php
@@ -363,12 +363,9 @@ abstract class AbstractPool
         $obj = $this->getObj($timeout);
         if ($obj) {
             $this->context[$cid] = $obj;
-            Coroutine::defer(function () use ($cid) {
-                if (isset($this->context[$cid])) {
-                    $obj = $this->context[$cid];
-                    unset($this->context[$cid]);
-                    $this->recycleObj($obj);
-                }
+            Coroutine::defer(function () use ($cid,$obj) {
+                //在recycle中已经处理过上下文，在此不需要判断是否存在上下文了。
+                $this->recycleObj($obj);
             });
             return $this->defer($timeout);
         } else {


### PR DESCRIPTION
当一个协程内invoke和defer同时出现时，invoke提前回收连接，且在回收时已经做了上下文的处理，由于是一个协程内，所以导致在协程退出时触发的defer 不能正确的回收defer的连接。因为在回收方法中已经把上下文处理了，在defer中判断永远为false，永远不能回收。